### PR TITLE
Add Kupyna hash family (Ukrainian national standard DSTU 7564:2014)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "farmhash",
  "fnv",
  "highway",
+ "kupyna",
  "md-5",
  "murmur3",
  "num_cpus",
@@ -468,6 +469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kupyna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8552d0116a202b5a4760c8bdb345db2121eefeb2730f7db04114167cae68a07"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ crc64fast = { version = "1.1.0", optional = true }
 farmhash = { version = "1.1.2", optional = true }
 fnv = { version = "1.0.7", optional = true }
 highway = { version = "1.3.0", optional = true }
+kupyna = { version = "0.1.0", optional = true }
 md-5 = { version = "0.10.6", optional = true }
 murmur3 = { version = "0.5.2", optional = true }
 ripemd = { version = "0.1.3", optional = true }
@@ -71,6 +72,7 @@ default = [
     "ripemd",
     "sm3",
     "streebog",
+    "kupyna",
     "whirlpool",
     "ascon",
     "crc",
@@ -101,6 +103,7 @@ md5 = ["dep:md-5"]
 ripemd = ["dep:ripemd"]
 sm3 = ["dep:sm3"]
 streebog = ["dep:streebog"]
+kupyna = ["dep:kupyna"]
 whirlpool = ["dep:whirlpool"]
 ascon = ["dep:ascon-hash"]
 crc = ["dep:crc32fast", "dep:crc32c", "dep:crc64fast"]

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The benchmark measures the time taken to hash the input data preloaded into heap
 
 ### Algorithms
 
-51 hashing algorithms are benchmarked across two categories.
+55 hashing algorithms are benchmarked across two categories.
 
-#### Cryptographic (32)
+#### Cryptographic (36)
 
 | Algorithm | Crate | Output (bits) | Notes |
 |---|---|---|---|
@@ -55,6 +55,10 @@ The benchmark measures the time taken to hash the input data preloaded into heap
 | SM3 | [`sm3`](https://crates.io/crates/sm3) | 256 | Chinese national standard (GB/T 32905-2016) |
 | Streebog-256 | [`streebog`](https://crates.io/crates/streebog) | 256 | Russian standard (GOST R 34.11-2012) |
 | Streebog-512 | [`streebog`](https://crates.io/crates/streebog) | 512 | Russian standard (GOST R 34.11-2012) |
+| Kupyna-224 | [`kupyna`](https://crates.io/crates/kupyna) | 224 | Ukrainian national standard (DSTU 7564:2014) |
+| Kupyna-256 | [`kupyna`](https://crates.io/crates/kupyna) | 256 | Ukrainian national standard (DSTU 7564:2014) |
+| Kupyna-384 | [`kupyna`](https://crates.io/crates/kupyna) | 384 | Ukrainian national standard (DSTU 7564:2014) |
+| Kupyna-512 | [`kupyna`](https://crates.io/crates/kupyna) | 512 | Ukrainian national standard (DSTU 7564:2014) |
 | Whirlpool | [`whirlpool`](https://crates.io/crates/whirlpool) | 512 | ISO/IEC 10118-3; used by VeraCrypt |
 | Ascon-Hash256 | [`ascon-hash`](https://crates.io/crates/ascon-hash) | 256 | NIST SP 800-232 lightweight standard |
 

--- a/src/algorithms/kupyna.rs
+++ b/src/algorithms/kupyna.rs
@@ -1,0 +1,70 @@
+//! Kupyna — Ukrainian national standard (DSTU 7564:2014).
+
+use crate::registry::{Algorithm, Category, OutputBits, Runner};
+use kupyna::Digest;
+use std::hint::black_box;
+
+/// Hash data using Kupyna-224.
+fn kupyna224(data: &[u8]) {
+    let mut hasher = kupyna::Kupyna224::new();
+    hasher.update(data);
+    black_box(hasher.finalize());
+}
+
+/// Hash data using Kupyna-256.
+fn kupyna256(data: &[u8]) {
+    let mut hasher = kupyna::Kupyna256::new();
+    hasher.update(data);
+    black_box(hasher.finalize());
+}
+
+/// Hash data using Kupyna-384.
+fn kupyna384(data: &[u8]) {
+    let mut hasher = kupyna::Kupyna384::new();
+    hasher.update(data);
+    black_box(hasher.finalize());
+}
+
+/// Hash data using Kupyna-512.
+fn kupyna512(data: &[u8]) {
+    let mut hasher = kupyna::Kupyna512::new();
+    hasher.update(data);
+    black_box(hasher.finalize());
+}
+
+pub fn algorithms() -> Vec<Algorithm> {
+    vec![
+        Algorithm {
+            name: "Kupyna-224",
+            crate_name: "kupyna",
+            output: OutputBits::Fixed(224),
+            category: Category::Cryptographic,
+            notes: "Ukrainian national standard (DSTU 7564:2014)",
+            runner: Runner::SingleStream(kupyna224),
+        },
+        Algorithm {
+            name: "Kupyna-256",
+            crate_name: "kupyna",
+            output: OutputBits::Fixed(256),
+            category: Category::Cryptographic,
+            notes: "Ukrainian national standard (DSTU 7564:2014)",
+            runner: Runner::SingleStream(kupyna256),
+        },
+        Algorithm {
+            name: "Kupyna-384",
+            crate_name: "kupyna",
+            output: OutputBits::Fixed(384),
+            category: Category::Cryptographic,
+            notes: "Ukrainian national standard (DSTU 7564:2014)",
+            runner: Runner::SingleStream(kupyna384),
+        },
+        Algorithm {
+            name: "Kupyna-512",
+            crate_name: "kupyna",
+            output: OutputBits::Fixed(512),
+            category: Category::Cryptographic,
+            notes: "Ukrainian national standard (DSTU 7564:2014)",
+            runner: Runner::SingleStream(kupyna512),
+        },
+    ]
+}

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -24,6 +24,8 @@ pub mod fnv;
 pub mod fxhash;
 #[cfg(feature = "highway")]
 pub mod highway;
+#[cfg(feature = "kupyna")]
+pub mod kupyna;
 #[cfg(feature = "md5")]
 pub mod md5;
 #[cfg(feature = "murmur3")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ pub fn registry() -> Vec<Algorithm> {
     algs.extend(algorithms::sm3::algorithms());
     #[cfg(feature = "streebog")]
     algs.extend(algorithms::streebog::algorithms());
+    #[cfg(feature = "kupyna")]
+    algs.extend(algorithms::kupyna::algorithms());
     #[cfg(feature = "whirlpool")]
     algs.extend(algorithms::whirlpool::algorithms());
     #[cfg(feature = "ascon")]

--- a/web/src/data/algorithms.json
+++ b/web/src/data/algorithms.json
@@ -272,6 +272,42 @@
       "notes": "Russian standard (GOST R 34.11-2012)"
     },
     {
+      "name": "Kupyna-224",
+      "crate": "kupyna",
+      "output_bits": 224,
+      "output_kind": "fixed",
+      "category": "cryptographic",
+      "internally_parallel": false,
+      "notes": "Ukrainian national standard (DSTU 7564:2014)"
+    },
+    {
+      "name": "Kupyna-256",
+      "crate": "kupyna",
+      "output_bits": 256,
+      "output_kind": "fixed",
+      "category": "cryptographic",
+      "internally_parallel": false,
+      "notes": "Ukrainian national standard (DSTU 7564:2014)"
+    },
+    {
+      "name": "Kupyna-384",
+      "crate": "kupyna",
+      "output_bits": 384,
+      "output_kind": "fixed",
+      "category": "cryptographic",
+      "internally_parallel": false,
+      "notes": "Ukrainian national standard (DSTU 7564:2014)"
+    },
+    {
+      "name": "Kupyna-512",
+      "crate": "kupyna",
+      "output_bits": 512,
+      "output_kind": "fixed",
+      "category": "cryptographic",
+      "internally_parallel": false,
+      "notes": "Ukrainian national standard (DSTU 7564:2014)"
+    },
+    {
       "name": "Whirlpool",
       "crate": "whirlpool",
       "output_bits": 512,


### PR DESCRIPTION
Adds Kupyna (DSTU 7564:2014) in all four output sizes (224/256/384/512) via the RustCrypto `kupyna` crate, bringing the total algorithm count from 51 to 55.

Closes #4.

## Summary

- Adds Kupyna-224, Kupyna-256, Kupyna-384, Kupyna-512 following the existing per-family module pattern
- LSH (KS X 3262) remains deferred — no maintained Rust crate exists for it

## Implementation

1. **Module**: `src/algorithms/kupyna.rs` with four single-stream runners, gated behind `#[cfg(feature = "kupyna")]`
2. **Crate**: optional `kupyna = "0.1.0"` dependency added to `Cargo.toml` and included in `default` features

## Followup

- Existing per-machine results files lack Kupyna cells and will be flagged by `verify` until benchmarks are re-run
